### PR TITLE
Use OpenShift's wildcard certs for the secure-sso route

### DIFF
--- a/bin/create-self-signed-certs.sh
+++ b/bin/create-self-signed-certs.sh
@@ -10,6 +10,7 @@ if [ ! -d .certs ]; then
 
     keytool -genkey -alias localhost -keyalg RSA -keypass $CERT_PASS -storepass $CERT_PASS -keystore keystore.jks  -dname 'cn=localhost, ou=localhost, o=localhost, c=NO' -validity 300
     keytool -export -alias localhost -storepass $CERT_PASS -file sso.crt -keystore keystore.jks
+    keytool -export -alias localhost -storepass $CERT_PASS -file sso-rfc.crt -keystore keystore.jks -rfc
     keytool -import -v -trustcacerts -alias localhost -file sso.crt -keystore truststore.jks -keypass $CERT_PASS -storepass $CERT_PASS -noprompt
 
     keytool -genseckey -alias jgroups -storetype JCEKS -keystore jgroups.jceks -keypass $CERT_PASS -storepass $CERT_PASS

--- a/bin/oc-create-sso-single.sh
+++ b/bin/oc-create-sso-single.sh
@@ -3,6 +3,8 @@
 cd `dirname $0`/..
 . config
 
+CA_CERT=`cat .certs/sso-rfc.crt`
+
 oc new-app -f sso-single.json \
 -p IMAGE_STREAM_NAMESPACE=sso \
 -p APPLICATION_NAME=sso \
@@ -14,4 +16,5 @@ oc new-app -f sso-single.json \
 -p SSO_TRUSTSTORE_PASSWORD=$CERT_PASS \
 -p JGROUPS_ENCRYPT_SECRET=sso-jgroup-secret \
 -p JGROUPS_ENCRYPT_PASSWORD=$CERT_PASS \
--p MEMORY_LIMIT=2Gi
+-p MEMORY_LIMIT=2Gi \
+-p CA_CERTIFICATE="$CA_CERT"

--- a/sso-single.json
+++ b/sso-single.json
@@ -275,6 +275,12 @@
             "name": "MEMORY_LIMIT",
             "value": "1Gi",
             "required": false
+        },
+        {
+            "description": "CA Certificate that OpenShift should trust when its router communicates with Keycloak over SSL",
+            "name": "CA_CERTIFICATE",
+            "value": "",
+            "required": true
         }
     ],
     "objects": [
@@ -417,7 +423,8 @@
                     "name": "secure-${APPLICATION_NAME}"
                 },
                 "tls": {
-                    "termination": "passthrough"
+                    "termination": "reencrypt",
+                    "destinationCACertificate": "${CA_CERTIFICATE}"
                 }
             }
         },


### PR DESCRIPTION
Take advantage of the OpenShift router's valid certificate and only
use the self-signed certificate for internal communication from the
OpenShift router to the SSO server. This gives us valid certificates
externally, assuming the OpenShift router is setup with a valid
wildcard certificate. And because we're reencrypting we get TLS
security all the way through to the SSO server.